### PR TITLE
Python 3 and Numpy array compatibility

### DIFF
--- a/hankel.py
+++ b/hankel.py
@@ -1,9 +1,9 @@
 '''
 General quadrature method for Hankel transformations.
 
-Based on the algorithm provided in 
+Based on the algorithm provided in
 H. Ogata, A Numerical Integration Formula Based on the Bessel Functions,
-Publications of the Research Institute for Mathematical Sciences, 
+Publications of the Research Institute for Mathematical Sciences,
 vol. 41, no. 4, pp. 949-970, 2005.
 '''
 
@@ -18,24 +18,24 @@ from scipy.special import j0, j1, jn_zeros, jn, yv, jv
 class HankelTransform(object):
     """
     The basis of the Hankel Transformation algorithm by Ogata 2005.
-    
+
     This algorithm is used to solve the equation :math:`\int_0^\infty f(x) J_\nu(x) dx`
-    where :math:`J_\nu(x)` is a Bessel function of the first kind of order 
+    where :math:`J_\nu(x)` is a Bessel function of the first kind of order
     :math:`nu`, and :math:`f(x)` is an arbitrary (slowly-decaying) function.
-    
-    The algorithm is presented in 
+
+    The algorithm is presented in
     H. Ogata, A Numerical Integration Formula Based on the Bessel Functions,
     Publications of the Research Institute for Mathematical Sciences, vol. 41, no. 4, pp. 949-970, 2005.
-    
+
     Parameters
     ----------
     nu : int or 0.5, optional, default = 0
         The order of the bessel function (of the first kind) J_nu(x)
-    
+
     N : int, optional, default = 100
         The number of nodes in the calculation. Generally this must increase
-        for a smaller value of the step-size h.     
-    
+        for a smaller value of the step-size h.
+
     h : float, optional, default = 0.1
         The step-size of the integration.
     """
@@ -49,9 +49,7 @@ class HankelTransform(object):
         self.dpsi = self._d_psi(h * self._zeros)
 
     def _psi(self, t):
-        print t
         y = np.sinh(t)
-        print y
         return t * np.tanh(np.pi * y / 2)
 
     def _d_psi(self, t):
@@ -97,15 +95,15 @@ class HankelTransform(object):
     def transform(self, f, ret_err=True, ret_cumsum=False):
         """
         Perform the transform of the function f
-        
+
         Parameters
         ----------
         f : callable
             A function of one variable, representing :math:`f(x)`
-            
+
         ret_err : boolean, optional, default = True
             Whether to return the estimated error
-            
+
         ret_cumsum : boolean, optional, default = False
             Whether to return the cumulative sum
         """
@@ -123,9 +121,9 @@ class HankelTransform(object):
 class SphericalHankelTransform(HankelTransform):
     """
     Perform spherical hankel transforms.
-    
+
     Defined as :math:`\int_0^\infty f(x) j_\nu(x) dx
-    
+
     .. Note :: Only does 0th-order transforms currently.
     """
     def __init__(self, nu=0, *args, **kwargs):

--- a/hankel.py
+++ b/hankel.py
@@ -109,11 +109,11 @@ class HankelTransform(object):
         """
         fres = self._f(f, self.x)
         summation = np.pi * self.w * fres * self.j * self.dpsi
-        ret = [np.sum(summation)]
+        ret = [np.sum(summation, axis=-1)]
         if ret_err:
-            ret.append(summation[-1])
+            ret.append(np.take(summation, -1, axis=-1))
         if ret_cumsum:
-            ret.append(np.cumsum(summation))
+            ret.append(np.cumsum(summation, axis=-1))
 
         return ret
 


### PR DESCRIPTION
I made some changes to be able to use the module with Python 3, and also to allow transforming a function that returns a Numpy `ndarray` instead of a number. This comes in handy when transforming a large number of functions with similar structure at once.

Most of the individual changes are just removal of trailing whitespace, which is just an incidental effect of my IDE.