### PR TITLE
fixed relative import for python3, still working with python2

### DIFF
--- a/hankel/__init__.py
+++ b/hankel/__init__.py
@@ -1,3 +1,3 @@
-from hankel import *
+from .hankel import *
 
 __version__ = '0.3.1'


### PR DESCRIPTION
Installation was not working for python3 but working for python2, I realised it was a relative import issue and I fixed it.