### PR TITLE
Add alternative hankel definition; handle k=0 input; restructuring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+unreleased
+----------
+**Enhancements**
+
+- Limit calculation for k=0 provided (resulted in nan before)
+- alternative hankel kernel now selectable: sqrt(x) * J(nu, x)
+
+**Bugfixes**
+
+- saver calculation of xrange_approx
+- caching of series factors for faster calculations
+
 0.3.9
 -----
 :tada: Version corresponding to JOSS paper release.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,11 @@ unreleased
 
 - Limit calculation for k=0 provided (resulted in nan before)
 - alternative hankel kernel now selectable: sqrt(x) * J(nu, x)
+- caching of series factors for faster calculations
 
 **Bugfixes**
 
 - saver calculation of xrange_approx
-- caching of series factors for faster calculations
 
 0.3.9
 -----

--- a/hankel/__init__.py
+++ b/hankel/__init__.py
@@ -32,4 +32,4 @@ from hankel.tools import get_h
 
 __all__ = ["HankelTransform", "SymmetricFourierTransform", "get_h"]
 
-__version__ = "0.3.9.dev0"
+__version__ = "1.0.0.dev0"

--- a/hankel/__init__.py
+++ b/hankel/__init__.py
@@ -27,8 +27,9 @@ Functions
 """
 from __future__ import absolute_import
 
-from hankel.hankel import HankelTransform, SymmetricFourierTransform, get_h
+from hankel.hankel import HankelTransform, SymmetricFourierTransform
+from hankel.tools import get_h
 
 __all__ = ["HankelTransform", "SymmetricFourierTransform", "get_h"]
 
-__version__ = "0.3.9"
+__version__ = "0.3.9.dev0"

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -15,7 +15,7 @@ from mpmath import fp as mpm
 from scipy.integrate import quad
 from hankel.tools import (
     d_psi,
-    j,
+    kernel,
     weight,
     roots,
     get_x,
@@ -76,7 +76,7 @@ class HankelTransform(object):
         self._h = h
         self._zeros = roots(N, nu)
         self.x = get_x(h, self._zeros)
-        self.j = j(self.x, nu, alt)
+        self.kernel = kernel(self.x, nu, alt)
         self.w = weight(nu, self._zeros)
         self.dpsi = d_psi(h * self._zeros)
         self.alt = alt
@@ -105,7 +105,7 @@ class HankelTransform(object):
         with np.errstate(divide="ignore"):  # numpy safely divids by 0
             args = np.divide.outer(self.x, k).T  # x = r*k
         fres = self._f(f, args)
-        return np.pi * self.w * fres * self.j * self.dpsi
+        return np.pi * self.w * fres * self.kernel * self.dpsi
 
     def transform(self, f, k=1, ret_err=True, ret_cumsum=False, inverse=False):
         r"""
@@ -171,9 +171,9 @@ class HankelTransform(object):
         # care about k = 0
         if np.any(k_0):
             # limit of J(nu, 0) considering powers of k
-            lim_k_pow = 0.5 if self.alt else 0  # in alt. def sqrt(k) involved
-            lim_r_pow = self._r_power + lim_k_pow + self.nu
-            nu_th = self._k_power - 1 - lim_k_pow  # threshold
+            alt_pow = 0.5 if self.alt else 0  # in alt. def sqrt(rk) involved
+            lim_r_pow = self._r_power + alt_pow + self.nu
+            nu_th = self._k_power - 1 - alt_pow  # threshold
             lim = j_lim(self.nu)
 
             def integrand(r):

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -11,7 +11,6 @@ from __future__ import division, absolute_import
 from builtins import super
 
 import numpy as np
-from mpmath import fp as mpm
 from scipy.integrate import quad
 from hankel.tools import (
     d_psi,
@@ -259,7 +258,7 @@ class HankelTransform(object):
         --------
         xrange: the actual x-range under a given choice of parameters.
         """
-        r = mpm.besseljzero(nu, 1) / np.pi
+        r = roots(1, nu)[0]
         return np.array(
             [np.pi ** 2 * h * r ** 2 / 2 / k, np.pi * np.pi / h / k]
         )

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -148,6 +148,7 @@ class HankelTransform(object):
         The inverse transform is identical (swapping *k* and *r* of course).
         """
         # The following allows for a re-scaling of k when doing FT's.
+        k_scalar = np.isscalar(k)
         k = self._k(k)
         # k = zero here
         k_0 = np.isclose(k, 0)
@@ -184,6 +185,9 @@ class HankelTransform(object):
                 ret[k_0] = np.inf
             else:
                 ret[k_0] = 0
+
+        if k_scalar:
+            ret = np.asscalar(ret)
 
         if ret_err:
             err = norm * np.take(summation, -1, axis=-1) / knorm

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -182,7 +182,7 @@ class HankelTransform(object):
             if np.isclose(self.nu, nu_th):
                 ret[k_0] = quad(integrand, 0, np.inf)[0] * lim * norm
             elif self.nu < nu_th:
-                ret[k_0] = np.inf
+                ret[k_0] = np.nan
             else:
                 ret[k_0] = 0
 

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -56,7 +56,7 @@ class HankelTransform(object):
     h : float, optional
         The step-size of the integration.
     alt : bool, optional
-        State if the alternative definition of the hankel transform
+        Whether to use the alternative definition of the hankel transform.
         should be used. Default: False
     """
 

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -187,7 +187,7 @@ class HankelTransform(object):
                 ret[k_0] = 0
 
         if k_scalar:
-            ret = np.asscalar(ret)
+            ret = ret.item()
 
         if ret_err:
             err = norm * np.take(summation, -1, axis=-1) / knorm

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -83,7 +83,7 @@ class HankelTransform(object):
 
         # Some quantities only useful in the FourierTransform
         self._r_power = 0 if alt else 1
-        self._k_power = 1
+        self._k_power = 0
 
     @property
     def nu(self):
@@ -159,7 +159,7 @@ class HankelTransform(object):
         norm = self._norm(inverse)
 
         # The following renormalises by the fourier dual to some power
-        knorm = safe_power(k, self._k_power)
+        knorm = safe_power(k, self._k_power + 1)
 
         # set replace k=0 with 1 in the following
         knorm[k_0] = 1
@@ -368,7 +368,7 @@ class SymmetricFourierTransform(HankelTransform):
         self.fourier_norm_a = a
         self.fourier_norm_b = b
         self._r_power = (ndim - 1) / 2.0 if alt else ndim / 2.0
-        self._k_power = (ndim + 1) / 2.0 if alt else ndim / 2.0
+        self._k_power = (ndim - 1) / 2.0 if alt else ndim / 2.0 - 1
 
     def _norm(self, inverse=False):
         r"""

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -157,14 +157,14 @@ class HankelTransform(object):
         # The following renormalises by the fourier dual to some power
         knorm = safe_power(k, self._k_power + self._r_power + 1)
 
-        # set replace k=0 with 1 in the following
+        # replace k=0 with 1
         knorm[k_0] = 1
         k[k_0] = 1
 
         summation = self._get_series(f, k)
         ret = np.array(norm * np.sum(summation, axis=-1) / knorm)
 
-        # care about k = 0
+        # care about k=0
         if np.any(k_0):
             # limit of J(nu, 0) considering powers of k
             alt_pow = 0.5 if self.alt else 0  # in alt. def sqrt(rk) involved

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -83,11 +83,20 @@ class HankelTransform(object):
         # Some quantities only useful in the FourierTransform
         self._r_power = 0 if alt else 1
         self._k_power = 0
+        # initialize the factors of the series
+        self._factor = None
 
     @property
     def nu(self):
         """Order of the hankel transform."""
         return self._nu
+
+    @property
+    def _series_fac(self):
+        """Factors for the series."""
+        if self._factor is None:
+            self._factor = np.pi * self.w * self.kernel * self.dpsi
+        return self._factor
 
     def _k(self, k):
         return np.array(k)
@@ -99,8 +108,7 @@ class HankelTransform(object):
     def _get_series(self, f, k=1):
         with np.errstate(divide="ignore"):  # numpy safely divids by 0
             args = np.divide.outer(self.x, k).T  # x = r*k
-        fres = f(args) * safe_power(self.x, self._r_power)
-        return np.pi * self.w * fres * self.kernel * self.dpsi
+        return self._series_fac * f(args) * safe_power(self.x, self._r_power)
 
     def transform(self, f, k=1, ret_err=True, ret_cumsum=False, inverse=False):
         r"""

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -165,7 +165,7 @@ class HankelTransform(object):
         k[k_0] = 1
 
         summation = self._get_series(f, k)
-        ret = norm * np.sum(summation, axis=-1) / knorm
+        ret = np.array(norm * np.sum(summation, axis=-1) / knorm)
 
         # care about k = 0
         if np.any(k_0):
@@ -180,7 +180,7 @@ class HankelTransform(object):
 
             if np.isclose(self.nu, nu_th):
                 ret[k_0] = quad(integrand, 0, np.inf)[0] * lim * norm
-            elif not self.alt and self.nu < nu_th:
+            elif self.nu < nu_th:
                 ret[k_0] = np.inf
             else:
                 ret[k_0] = 0
@@ -374,7 +374,7 @@ class SymmetricFourierTransform(HankelTransform):
 
     def _k(self, k):
         """Substitution for k."""
-        return np.array(self.fourier_norm_b * k)
+        return np.array(self.fourier_norm_b * np.array(k))
 
     @classmethod
     def xrange_approx(cls, h, ndim, k=1):

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -219,8 +219,12 @@ class HankelTransform(object):
         ret_cumsum : boolean, optional, default = False
             Whether to return the cumulative sum
         """
+        if self.alt:
+            func = lambda x: f(x) / np.sqrt(x)
+        else:
+            func = lambda x: f(x) / x
         return self.transform(
-            f=lambda x: f(x) / x,
+            f=func,
             k=1,
             ret_err=ret_err,
             ret_cumsum=ret_cumsum,

--- a/hankel/hankel.py
+++ b/hankel/hankel.py
@@ -7,13 +7,23 @@ Publications of the Research Institute for Mathematical Sciences,
 vol. 41, no. 4, pp. 949-970, 2005.
 """
 
-# TODO: Suppress warnings on overflows
 from __future__ import division, absolute_import
 from builtins import super
 
 import numpy as np
 from mpmath import fp as mpm
-from scipy.special import j0, j1, jn_zeros as _jn_zeros, jn, yv, jv
+from scipy.integrate import quad
+from hankel.tools import (
+    d_psi,
+    j,
+    weight,
+    roots,
+    get_x,
+    fourier_norm,
+    dim_to_nu,
+    safe_power,
+    j_lim,
+)
 
 
 class HankelTransform(object):
@@ -35,128 +45,66 @@ class HankelTransform(object):
 
     Parameters
     ----------
-
     nu : scalar, optional
         The order of the bessel function (of the first kind) J_nu(x)
-
     N : int, optional, default = ``pi/h``
         The number of nodes in the calculation. Generally this must increase
         for a smaller value of the step-size h. Default value is based on where
         the series will truncate according
         to the double-exponential convergence to
         the roots of the Bessel function.
-
     h : float, optional
         The step-size of the integration.
+    alt : bool, optional
+        State if the alternative definition of the hankel transform
+        should be used. Default: False
     """
 
-    def __init__(self, nu=0, N=None, h=0.05):
+    def __init__(self, nu=0, N=None, h=0.05, alt=False):
 
-        if N is None:
-            N = int(np.pi / h)
-
+        N = int(np.pi / h) if N is None else N
         if not np.isscalar(N):
             raise ValueError("N must be a scalar")
         if not np.isscalar(h):
             raise ValueError("h must be a scalar")
         if not np.isscalar(nu):
             raise ValueError("nu must be a scalar")
+        if nu < -0.5:
+            raise ValueError("nu must be at least -1/2")
 
         self._nu = nu
         self._h = h
-        self._zeros = self._roots(N)
-        self.x = self._x(h)
-        self.j = self._j(self.x)
-        self.w = self._weight()
-        self.dpsi = self._d_psi(h * self._zeros)
+        self._zeros = roots(N, nu)
+        self.x = get_x(h, self._zeros)
+        self.j = j(self.x, nu, alt)
+        self.w = weight(nu, self._zeros)
+        self.dpsi = d_psi(h * self._zeros)
+        self.alt = alt
 
         # Some quantities only useful in the FourierTransform
-        self._x_power = 1
-        self._k_power = 2
+        self._r_power = 0 if alt else 1
+        self._k_power = 1
 
-    def _psi(self, t):
-        y = np.sinh(t)
-        return t * np.tanh(np.pi * y / 2)
+    @property
+    def nu(self):
+        """Order of the hankel transform."""
+        return self._nu
 
-    def _d_psi(self, t):
-        a = np.ones_like(t)
-        mask = t < 6
-        t = t[mask]
-        a[mask] = (np.pi * t * np.cosh(t) + np.sinh(np.pi * np.sinh(t))) / (
-                1.0 + np.cosh(np.pi * np.sinh(t))
-            )
+    def _f(self, f, r):
+        """Correct integrand depending on transformation definition."""
+        return f(r) * safe_power(r, self._r_power)
 
-        # a[t<6] = (np.pi * t * np.cosh(t) + np.sinh(np.pi * np.sinh(t))) / (
-        #         1.0 + np.cosh(np.pi * np.sinh(t))
-        #     )
-        # with warnings.catch_warnings():
-        #     warnings.simplefilter("ignore")
-        #     a =
-        #
-        # a[np.isnan(a)] = 1.0
-        return a
+    def _k(self, k):
+        return np.array(k)
 
-    def _weight(self):
-        return yv(self._nu, np.pi * self._zeros) / self._j1(
-            np.pi * self._zeros
-        )
-
-    def _roots(self, N):
-        if np.floor(self._nu) == self._nu:
-            return _jn_zeros(self._nu, N) / np.pi
-        elif np.isclose(self._nu, 0.5):
-            # J[0.5] = sqrt(2/(x*pi))*sin(x)
-            return np.arange(1, N + 1)
-        elif np.isclose(self._nu, -0.5):
-            # J[-0.5] = sqrt(2/(x*pi))*cos(x)
-            return np.arange(1, N + 1) - 0.5
-        else:
-            return (
-                np.array([mpm.besseljzero(self._nu, i + 1) for i in range(N)])
-                / np.pi
-            )
-
-    def _j(self, x):
-        if self._nu == 0:
-            return j0(x)
-        elif self._nu == 1:
-            return j1(x)
-        elif np.floor(self._nu) == self._nu:
-            return jn(self._nu, x)
-        else:
-            return jv(self._nu, x)
-
-    def _j1(self, x):
-        if self._nu == -1:
-            return j0(x)
-        elif self._nu == 0:
-            return j1(x)
-        elif np.floor(self._nu) == self._nu:
-            return jn(self._nu + 1, x)
-        else:
-            return jv(self._nu + 1, x)
-
-    def _x(self, h):
-        return np.pi * self._psi(h * self._zeros) / h
-
-    def _f(self, f, x):
-        return f(x)
-
-    @staticmethod
-    def _k(k):
-        return k
-
-    @staticmethod
     def _norm(self, inverse=False):
-        r"""
-        Scalar normalisation of the transform. Identically 1.
-        """
+        r"""Scalar normalisation of the transform. Identically 1."""
         return 1
 
     def _get_series(self, f, k=1):
-        fres = (
-            self._f(f, np.divide.outer(self.x, k).T) * self.x ** self._x_power
-        )
+        with np.errstate(divide="ignore"):  # numpy safely divids by 0
+            args = np.divide.outer(self.x, k).T  # x = r*k
+        fres = self._f(f, args)
         return np.pi * self.w * fres * self.j * self.dpsi
 
     def transform(self, f, k=1, ret_err=True, ret_cumsum=False, inverse=False):
@@ -167,10 +115,8 @@ class HankelTransform(object):
         ----------
         f : callable
             A function of one variable, representing :math:`f(x)`
-
         ret_err : boolean, optional, default = True
             Whether to return the estimated error
-
         ret_cumsum : boolean, optional, default = False
             Whether to return the cumulative sum
 
@@ -179,18 +125,15 @@ class HankelTransform(object):
         ret : array-like
             The Hankel-transform of f(x) at the provided k. If
             `k` is scalar, then this will be scalar.
-
         err : array-like
             The estimated error of the approximate integral, at every `k`.
             It is merely the last term in the sum.
             Only returned if `ret_err=True`.
-
         cumsum : array-like
             The total cumulative sum, for which the last term
             is itself the transform.
             One can use this to check whether the integral is converging.
             Only returned if `ret_cumsum=True`
-
 
         Notes
         -----
@@ -198,10 +141,16 @@ class HankelTransform(object):
 
         .. math:: F(k) = \int_0^\infty r f(r) J_\nu(kr) dr.
 
+        Or in the alternative case with ``alt=True``:
+
+        .. math:: F(k) = \int_0^\infty f(r) \sqrt{kr} J_\nu(kr) dr.
+
         The inverse transform is identical (swapping *k* and *r* of course).
         """
         # The following allows for a re-scaling of k when doing FT's.
         k = self._k(k)
+        # k = zero here
+        k_0 = np.isclose(k, 0)
 
         # The following is the scalar normalisation of the transform
         # The basic transform has a norm of 1.
@@ -209,10 +158,32 @@ class HankelTransform(object):
         norm = self._norm(inverse)
 
         # The following renormalises by the fourier dual to some power
-        knorm = k ** self._k_power
+        knorm = safe_power(k, self._k_power)
+
+        # set replace k=0 with 1 in the following
+        knorm[k_0] = 1
+        k[k_0] = 1
 
         summation = self._get_series(f, k)
         ret = norm * np.sum(summation, axis=-1) / knorm
+
+        # care about k = 0
+        if np.any(k_0):
+            # limit of J(nu, 0) considering powers of k
+            lim_k_pow = 0.5 if self.alt else 0  # in alt. def sqrt(k) involved
+            lim_r_pow = self._r_power + lim_k_pow + self.nu
+            nu_th = self._k_power - 1 - lim_k_pow  # threshold
+            lim = j_lim(self.nu)
+
+            def integrand(r):
+                return f(r) * safe_power(r, lim_r_pow)
+
+            if np.isclose(self.nu, nu_th):
+                ret[k_0] = quad(integrand, 0, np.inf)[0] * lim * norm
+            elif not self.alt and self.nu < nu_th:
+                ret[k_0] = np.inf
+            else:
+                ret[k_0] = 0
 
         if ret_err:
             err = norm * np.take(summation, -1, axis=-1) / knorm
@@ -221,12 +192,11 @@ class HankelTransform(object):
 
         if ret_err and ret_cumsum:
             return ret, err, cumsum
-        elif ret_err:
+        if ret_err:
             return ret, err
-        elif ret_cumsum:
+        if ret_cumsum:
             return ret, cumsum
-        else:
-            return ret
+        return ret
 
     def integrate(self, f, ret_err=True, ret_cumsum=False):
         r"""
@@ -240,10 +210,8 @@ class HankelTransform(object):
         ----------
         f : callable
             A function of one variable, representing :math:`f(x)`
-
         ret_err : boolean, optional, default = True
             Whether to return the estimated error
-
         ret_cumsum : boolean, optional, default = False
             Whether to return the cumulative sum
         """
@@ -292,15 +260,17 @@ class HankelTransform(object):
         xrange: the actual x-range under a given choice of parameters.
         """
         r = mpm.besseljzero(nu, 1) / np.pi
-        return np.array([np.pi ** 2 * h * r ** 2 / 2 / k,
-                         np.pi * np.pi / h / k])
+        return np.array(
+            [np.pi ** 2 * h * r ** 2 / 2 / k, np.pi * np.pi / h / k]
+        )
 
     @classmethod
     def G(cls, f, h, k=None, *args, **kwargs):
         """
+        Info about the last term in the series.
+
         The absolute value of the non-oscillatory
         of the summed series' last term, up to a scaling constant.
-
         This can be used to get the sign of the slope of G with h.
 
         Parameters
@@ -319,12 +289,11 @@ class HankelTransform(object):
         """
         if k is None:
             return np.sqrt(2 * h / np.pi) * f(np.pi * np.pi / h)
-        else:
-            return np.sqrt(np.pi / (2 * h)) * f(np.pi * np.pi / h / k)
+        return np.sqrt(np.pi / (2 * h)) * f(np.pi * np.pi / h / k)
 
     @classmethod
     def deltaG(cls, f, h, *args, **kwargs):
-        "The slope (up to a constant) of the last term of the series with h"
+        """Slope (up to a constant) of the last term of the series with h."""
         return cls.G(f, h, *args, **kwargs) - cls.G(
             f, h / 1.1, *args, **kwargs
         )
@@ -332,24 +301,23 @@ class HankelTransform(object):
 
 class SymmetricFourierTransform(HankelTransform):
     r"""
-    Determine the Fourier Transform of a radially symmetric function
-    in arbitrary dimensions.
+    Fourier Transform of a radially symmetric function in arbitrary dimensions.
 
     Parameters
     ----------
     ndim : int
         Number of dimensions the transform is in.
-
     a, b : float, default 1
         This pair of values defines the Fourier convention used
         (see Notes below for details)
-
     N : int, optional
         The number of nodes in the calculation. Generally this must increase
         for a smaller value of the step-size h.
-
     h : float, optional
         The step-size of the integration.
+    alt : bool, optional
+        State if the alternative definition of the hankel transform
+        should be used. Default: False
 
     Notes
     -----
@@ -384,73 +352,29 @@ class SymmetricFourierTransform(HankelTransform):
 
     """
 
-    def __init__(self, ndim=2, a=1, b=1, N=None, h=0.05):
-        # keep int-type in python 3
-        if np.isclose(ndim % 2, 0):
-            nu = int(ndim) // 2 - 1
-        else:
-            nu = ndim / 2.0 - 1
+    def __init__(self, ndim=2, a=1, b=1, N=None, h=0.05, alt=True):
+
+        super().__init__(nu=dim_to_nu(ndim), N=N, h=h, alt=alt)
 
         self.ndim = ndim
         self.fourier_norm_a = a
         self.fourier_norm_b = b
-
-        super().__init__(nu=nu, N=N, h=h)
-
-        self._x_power = self.ndim / 2.0
-        self._k_power = self.ndim
-
-    def _fourier_norm(self, inverse=False):
-        r"""
-        Calculate fourier-pair normalisations.
-
-        See class documentation for details.
-        """
-        if inverse:
-            return (
-                np.sqrt(
-                    np.abs(self.fourier_norm_b)
-                    / (2 * np.pi) ** (1 + self.fourier_norm_a)
-                )
-                ** self.ndim
-            )
-        else:
-            return (
-                np.sqrt(
-                    np.abs(self.fourier_norm_b)
-                    / (2 * np.pi) ** (1 - self.fourier_norm_a)
-                )
-                ** self.ndim
-            )
+        self._r_power = (ndim - 1) / 2.0 if alt else ndim / 2.0
+        self._k_power = (ndim + 1) / 2.0 if alt else ndim / 2.0
 
     def _norm(self, inverse=False):
         r"""
-        The scalar normalisation of the transform,
-        taking into account Fourier conventions and a possible inversion.
+        Scalar normalisation of the transform.
+
+        Taking into account Fourier conventions and a possible inversion.
         """
-        return (2 * np.pi) ** (self.ndim / 2.0) * self._fourier_norm(inverse)
-
-    def transform(self, f, k, *args, **kwargs):
-        r"""
-        Do the *n*-symmetric Fourier transform of the function f.
-
-        Parameters and returns are precisely the same as
-        :meth:`HankelTransform.transform`.
-
-        Notes
-        -----
-        The *n*-symmetric fourier transform is defined
-        in terms of the Hankel transform as
-
-        .. math:: F(k) = \frac{(2\pi)^{n/2}}{k^{n/2-1}}
-                  \int_0^\infty r^{n/2-1} f(r) J_{n/2-1}(kr)r dr.
-
-        The inverse transform has an inverse normalisation.
-        """
-        k = self.fourier_norm_b * k
-        return super().transform(
-            f, k, *args, **kwargs
+        return (2 * np.pi) ** (self.ndim / 2.0) * fourier_norm(
+            self.fourier_norm_a, self.fourier_norm_b, self.ndim, inverse
         )
+
+    def _k(self, k):
+        """Substitution for k."""
+        return np.array(self.fourier_norm_b * k)
 
     @classmethod
     def xrange_approx(cls, h, ndim, k=1):
@@ -463,10 +387,8 @@ class SymmetricFourierTransform(HankelTransform):
         ----------
         h : float
             The resolution parameter of the Hankel integration
-
         ndim : float
             Number of dimensions of the transform.
-
         k : array-like, optional
             Scales for the transformation. Leave as 1 for an integral.
 
@@ -474,14 +396,15 @@ class SymmetricFourierTransform(HankelTransform):
         --------
         xrange:  the actual x-range under a given choice of parameters.
         """
-        return HankelTransform.xrange_approx(h, ndim / 2.0 - 1, k)
+        return HankelTransform.xrange_approx(h, dim_to_nu(ndim), k)
 
     @classmethod
-    def G(self, f, h, k=None, ndim=2):
+    def G(cls, f, h, k=None, ndim=2):
         """
+        Info about the last term in the series.
+
         The absolute value of the non-oscillatory part
         of the summed series' last term, up to a scaling constant.
-
         This can be used to get the sign of the slope of G with h.
 
         Parameters
@@ -502,143 +425,5 @@ class SymmetricFourierTransform(HankelTransform):
         """
         if k is None:
             return HankelTransform.G(f, h, k)
-        else:
-            fmax = f(self.xrange_approx(h, ndim, k)[-1])
-            return (np.pi / h) ** ((ndim - 1) / 2.0) * fmax
-
-
-def get_h(
-    f,
-    nu,
-    K=None,
-    cls=HankelTransform,
-    hstart=0.05,
-    hdecrement=2,
-    atol=1e-3,
-    rtol=1e-3,
-    maxiter=15,
-    inverse=False,
-):
-    """
-    Determine the largest value of h which gives a converged solution.
-
-    Parameters
-    ----------
-    f : callable
-        The function to be integrated/transformed.
-    nu : float
-        Either the order of the transformation, or the number of dimensions
-        (if `cls` is a :class:`SymmetricFourierTransform`)
-    K : float or array-like, optional
-        The scale(s) of the transformation.
-        If None, assumes an integration over f(x)J_nu(x) is desired.
-        It is recommended to use a down-sampled K
-        for this routine for efficiency. Often a min/max is enough.
-    cls : :class:`HankelTransform` subclass, optional
-        Either :class:`HankelTransform` or a subclass,
-        specifying the type of transformation to do on `f`.
-    hstart : float, optional
-        The starting value of h.
-    hdecrement : float, optional
-        How much to divide h by on each iteration.
-    atol, rtol : float, optional
-        The tolerance parameters, passed to `np.isclose`,
-        defining the stopping condition.
-    maxiter : int, optional
-        Maximum number of iterations to perform.
-    inverse : bool, optional
-        Whether to treat as an inverse transformation.
-
-    Returns
-    -------
-    h : float
-        The h value at which the solution converges.
-    res : scalar or tuple
-        The value of the integral/transformation using the returned h --
-        if a transformation, returns results at K.
-    N : int
-        The number of nodes necessary in the final calculation.
-        While each iteration uses N=pi/h, the returned N checks
-        whether nodes are numerically zero above some threshold.
-
-    Notes
-    -----
-    This function is not completely general. The function `f` is assumed to be
-    reasonably smooth and non-oscillatory.
-
-    The idea is to use successively smaller values of *h*, with N=pi/h on each
-    iteration, until the result betweeniterations becomes stable.
-    """
-
-    if hstart >= 1:
-        raise ValueError("h should never be greater than unity")
-
-    # First, ensure that *some* of the values are non-zero
-    i = 0
-    while (
-        np.any(
-            np.all(
-                cls(nu, h=hstart, N=int(np.pi / hstart))._get_series(
-                    f, 1 if K is None else K
-                ) == 0,
-                axis=-1,
-            )
-        )
-        and i < maxiter
-    ):
-        hstart /= hdecrement
-        i += 1
-
-    if i == maxiter:
-        raise Exception("Maxiter reached while checking for non-zero values")
-
-    if K is None:  # Do a normal integral of f(x)J_nu(x)
-        K = 1
-
-        def getres(h):
-            """dummy function to get the result"""
-            return cls(nu, h=h, N=int(np.pi / h)).transform(
-                lambda x: f(x) / x, k=K, ret_err=False, inverse=inverse
-            )
-
-    else:  # Do a transform at k=K
-        def getres(h):
-            """dummy function to get the result"""
-            return cls(nu, h=h, N=int(np.pi / h)).transform(
-                f, k=K, ret_err=False, inverse=inverse
-            )
-
-    res = getres(hstart)
-    res2 = 2 * res + 10
-
-    while not np.allclose(res, res2, atol=atol, rtol=rtol) and i < maxiter:
-        i += 1
-        hstart /= hdecrement
-        res2 = 1 * res
-        res = getres(hstart)
-
-    if i == maxiter:
-        raise Exception("Maxiter reached while checking convergence")
-
-    # Can do some more trimming of N potentially, by seeing where f(x)~0.
-    def consecutive(data, stepsize=1):
-        """split into arrays of consecutive zeros"""
-        return np.split(data, np.where(np.diff(data) != stepsize)[0] + 1)
-
-    hstart *= hdecrement
-
-    x = cls(nu, h=hstart, N=int(np.pi / hstart)).x
-    lastk = np.where(f(x / np.max(K)) == 0)[0]
-    if len(lastk) > 1:
-        # if there are any that are zero,
-        # and if there are more than 1 in a row
-        # (otherwise might just be oscillatory)
-        lastk = consecutive(lastk)  # split into arrays of consecutive zeros
-        if len(lastk[-1]) == 1:
-            lastk = int(np.pi / hstart)
-        else:
-            lastk = lastk[-1][0]
-    else:  # otherwise set back to N
-        lastk = int(np.pi / hstart)
-
-    return hstart, res2, lastk
+        fmax = f(cls.xrange_approx(h, ndim, k)[-1])
+        return (np.pi / h) ** ((ndim - 1) / 2.0) * fmax

--- a/hankel/tools.py
+++ b/hankel/tools.py
@@ -63,9 +63,11 @@ def j_lim(nu):
     return 0.5 ** nu / gamma(nu + 1)
 
 
-def j(x, nu, alt=False):
+def kernel(x, nu, alt=False):
     """
-    Bessel J(nu, x) functions for the hankel transformation.
+    Kernel functions for the hankel transformation.
+
+    J(nu, x) or for alt=True: J(nu, x) * sqrt(x).
 
     Parameters
     ----------

--- a/hankel/tools.py
+++ b/hankel/tools.py
@@ -76,7 +76,7 @@ def kernel(x, nu, alt=False):
     nu : int or float
         order of the bessel function.
     alt : bool, optional
-        State if the alternative defintion of the hankel transform should be
+        Whether the alternative defintion of the hankel transform should be
         used: J(nu, x)*sqrt(x). The default is False.
 
     Returns

--- a/hankel/tools.py
+++ b/hankel/tools.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+r"""Tools for Hankel transformations."""
+
+from __future__ import division, absolute_import
+
+import numpy as np
+from mpmath import fp as mpm
+from scipy.special import j0, j1, jn_zeros as _jn_zeros, jn, yv, jv, gamma
+
+
+SRPI2 = np.sqrt(np.pi / 2.0)
+
+
+def psi(t):
+    """Variable transform from Ogata 2005."""
+    return t * np.tanh(np.pi * np.sinh(t) / 2)
+
+
+def d_psi(t):
+    """Derivative of the Variable transform from Ogata 2005."""
+    t = np.array(t, dtype=float)
+    a = np.ones_like(t)
+    mask = t < 6
+    t = t[mask]
+    a[mask] = (np.pi * t * np.cosh(t) + np.sinh(np.pi * np.sinh(t))) / (
+        1.0 + np.cosh(np.pi * np.sinh(t))
+    )
+    return a
+
+
+def weight(nu, zeros):
+    """Weights for the summation in the hankel transformation."""
+    return yv(nu, np.pi * zeros) / j(np.pi * zeros, nu + 1)
+
+
+def roots(N, nu):
+    """First N Roots of the Bessel J(nu) functions divided by pi."""
+    if np.isclose(nu, np.floor(nu)):
+        return _jn_zeros(nu, N) / np.pi
+    if np.isclose(nu, 0.5):
+        # J[0.5] = sqrt(2/(x*pi))*sin(x)
+        return np.arange(1, N + 1)
+    if np.isclose(nu, -0.5):
+        # J[-0.5] = sqrt(2/(x*pi))*cos(x)
+        return np.arange(1, N + 1) - 0.5
+    return np.array([mpm.besseljzero(nu, i + 1) for i in range(N)]) / np.pi
+
+
+def j_lim(nu):
+    """
+    Limit factor of Bessel J(nu, 0) = 0.5 ** nu / Gamma(nu + 1).
+
+    Parameters
+    ----------
+    nu : float
+        Order of the Bessel function.
+
+    Returns
+    -------
+    float
+        The factor.
+    """
+    return 0.5 ** nu / gamma(nu + 1)
+
+
+def j(x, nu, alt=False):
+    """
+    Bessel J(nu, x) functions for the hankel transformation.
+
+    Parameters
+    ----------
+    x : array-like
+        input values.
+    nu : int or float
+        order of the bessel function.
+    alt : bool, optional
+        State if the alternative defintion of the hankel transform should be
+        used: J(nu, x)*sqrt(x). The default is False.
+
+    Returns
+    -------
+    array-like
+        The needed function for the hankel transformation.
+
+    Notes
+    -----
+    J(nu, x) is approximately (x/2)^nu / Gamma(nu+1) for small x.
+    """
+    if alt:
+        if np.isclose(nu, 0):
+            return j0(x) * np.sqrt(x)
+        if np.isclose(nu, 1):
+            return j1(x) * np.sqrt(x)
+        if np.isclose(nu, 0.5):  # J[0.5] = sqrt(2/(x*pi))*sin(x)
+            return np.sin(x) / SRPI2
+        if np.isclose(nu, -0.5):  # J[-0.5] = sqrt(2/(x*pi))*cos(x)
+            return np.cos(x) / SRPI2
+        if np.isclose(nu, np.floor(nu)):
+            return jn(int(nu), x) * np.sqrt(x)
+        return jv(nu, x) * np.sqrt(x)
+    if np.isclose(nu, 0):
+        return j0(x)
+    if np.isclose(nu, 1):
+        return j1(x)
+    if np.isclose(nu, np.floor(nu)):
+        return jn(int(nu), x)
+    return jv(nu, x)
+
+
+def safe_power(x, p):
+    """
+    Safely calculate x**p.
+
+    Parameters
+    ----------
+    x : array-like
+        value.
+    p : float
+        exponent.
+
+    Returns
+    -------
+    array-like
+        The result x**p.
+    """
+    return np.ones_like(x) if np.isclose(p, 0) else np.array(x ** p)
+
+
+def get_x(h, zeros):
+    """Get the arguments for the integrand."""
+    return np.pi * psi(h * zeros) / h
+
+
+def fourier_norm(a, b, ndim, inverse=False):
+    r"""Calculate fourier-pair normalisations."""
+    if inverse:
+        return np.sqrt(np.abs(b) / (2 * np.pi) ** (1 + a)) ** ndim
+    return np.sqrt(np.abs(b) / (2 * np.pi) ** (1 - a)) ** ndim
+
+
+def dim_to_nu(ndim):
+    """Calculate nu for the Hankel Transformation."""
+    # keep int-type in python 3
+    if np.isclose(ndim % 2, 0):
+        return int(ndim) // 2 - 1
+    return ndim / 2.0 - 1
+
+
+def get_h(
+    f,
+    nu,
+    K=None,
+    cls=None,
+    hstart=0.05,
+    hdecrement=2,
+    atol=1e-3,
+    rtol=1e-3,
+    maxiter=15,
+    inverse=False,
+):
+    """
+    Determine the largest value of h which gives a converged solution.
+
+    Parameters
+    ----------
+    f : callable
+        The function to be integrated/transformed.
+    nu : float
+        Either the order of the transformation, or the number of dimensions
+        (if `cls` is a :class:`SymmetricFourierTransform`)
+    K : float or array-like, optional
+        The scale(s) of the transformation.
+        If None, assumes an integration over f(x)J_nu(x) is desired.
+        It is recommended to use a down-sampled K
+        for this routine for efficiency. Often a min/max is enough.
+    cls : :class:`HankelTransform` subclass, optional
+        Either :class:`HankelTransform` or a subclass,
+        specifying the type of transformation to do on `f`.
+    hstart : float, optional
+        The starting value of h.
+    hdecrement : float, optional
+        How much to divide h by on each iteration.
+    atol, rtol : float, optional
+        The tolerance parameters, passed to `np.isclose`,
+        defining the stopping condition.
+    maxiter : int, optional
+        Maximum number of iterations to perform.
+    inverse : bool, optional
+        Whether to treat as an inverse transformation.
+
+    Returns
+    -------
+    h : float
+        The h value at which the solution converges.
+    res : scalar or tuple
+        The value of the integral/transformation using the returned h --
+        if a transformation, returns results at K.
+    N : int
+        The number of nodes necessary in the final calculation.
+        While each iteration uses N=pi/h, the returned N checks
+        whether nodes are numerically zero above some threshold.
+
+    Notes
+    -----
+    This function is not completely general. The function `f` is assumed to be
+    reasonably smooth and non-oscillatory.
+
+    The idea is to use successively smaller values of *h*, with N=pi/h on each
+    iteration, until the result betweeniterations becomes stable.
+    """
+    # prevent circular imports
+    from hankel.hankel import HankelTransform
+
+    cls = HankelTransform if cls is None else cls
+
+    if hstart >= 1:
+        raise ValueError("h should never be greater than unity")
+
+    # First, ensure that *some* of the values are non-zero
+    i = 0
+    while (
+        np.any(
+            np.all(
+                cls(nu, h=hstart, N=int(np.pi / hstart))._get_series(
+                    f, 1 if K is None else K
+                ) == 0,
+                axis=-1,
+            )
+        )
+        and i < maxiter
+    ):
+        hstart /= hdecrement
+        i += 1
+
+    if i == maxiter:
+        raise Exception("Maxiter reached while checking for non-zero values")
+
+    if K is None:  # Do a normal integral of f(x)J_nu(x)
+        K = 1
+
+        def getres(h):
+            """Dummy function to get the result."""
+            return cls(nu, h=h, N=int(np.pi / h)).transform(
+                lambda x: f(x) / x, k=K, ret_err=False, inverse=inverse
+            )
+
+    else:  # Do a transform at k=K
+        def getres(h):
+            """Dummy function to get the result."""
+            return cls(nu, h=h, N=int(np.pi / h)).transform(
+                f, k=K, ret_err=False, inverse=inverse
+            )
+
+    res = getres(hstart)
+    res2 = 2 * res + 10
+
+    while not np.allclose(res, res2, atol=atol, rtol=rtol) and i < maxiter:
+        i += 1
+        hstart /= hdecrement
+        res2 = 1 * res
+        res = getres(hstart)
+
+    if i == maxiter:
+        raise Exception("Maxiter reached while checking convergence")
+
+    # Can do some more trimming of N potentially, by seeing where f(x)~0.
+    def consecutive(data, stepsize=1):
+        """Split into arrays of consecutive zeros."""
+        return np.split(data, np.where(np.diff(data) != stepsize)[0] + 1)
+
+    hstart *= hdecrement
+
+    x = cls(nu, h=hstart, N=int(np.pi / hstart)).x
+    lastk = np.where(f(x / np.max(K)) == 0)[0]
+    if len(lastk) > 1:
+        # if there are any that are zero,
+        # and if there are more than 1 in a row
+        # (otherwise might just be oscillatory)
+        lastk = consecutive(lastk)  # split into arrays of consecutive zeros
+        if len(lastk[-1]) == 1:
+            lastk = int(np.pi / hstart)
+        else:
+            lastk = lastk[-1][0]
+    else:  # otherwise set back to N
+        lastk = int(np.pi / hstart)
+
+    return hstart, res2, lastk

--- a/hankel/tools.py
+++ b/hankel/tools.py
@@ -30,7 +30,7 @@ def d_psi(t):
 
 def weight(nu, zeros):
     """Weights for the summation in the hankel transformation."""
-    return yv(nu, np.pi * zeros) / j(np.pi * zeros, nu + 1)
+    return yv(nu, np.pi * zeros) / kernel(np.pi * zeros, nu + 1)
 
 
 def roots(N, nu):

--- a/hankel/tools.py
+++ b/hankel/tools.py
@@ -223,7 +223,8 @@ def get_h(
             np.all(
                 cls(nu, h=hstart, N=int(np.pi / hstart))._get_series(
                     f, 1 if K is None else K
-                ) == 0,
+                )
+                == 0,
                 axis=-1,
             )
         )
@@ -245,6 +246,7 @@ def get_h(
             )
 
     else:  # Do a transform at k=K
+
         def getres(h):
             """Dummy function to get the result."""
             return cls(nu, h=h, N=int(np.pi / h)).transform(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,9 @@
-'''
+"""
 This module provides some tests of the API of hankel.
 
 That is, it tests stuff like whether one can input scalars/arrays, and whether the outputs of functions have the correct
 number of entries etc.
-'''
+"""
 
 import numpy as np
 import pytest
@@ -29,34 +29,34 @@ def test_array_nu():
 def test_k_array():
     k = np.logspace(-3, 3, 10)
     ht = HankelTransform(N=50)
-    res = ht.transform(lambda x: 1. / x, k, False)
+    res = ht.transform(lambda x: 1.0 / x, k, False)
     assert len(res) == 10
 
 
 def test_k_scalar():
     k = 1
     ht = HankelTransform(N=50)
-    res = ht.transform(lambda x: 1. / x, k, False)
+    res = ht.transform(lambda x: 1.0 / x, k, False)
     assert np.isscalar(res)
 
 
 def test_ret_err():
     ht = HankelTransform(N=50)
-    res, err = ht.integrate(lambda x: 1. / x, True)
+    res, err = ht.integrate(lambda x: 1.0 / x, True)
 
 
 def test_ret_cumsum():
     ht = HankelTransform(N=50)
-    res, cumsum = ht.integrate(lambda x: 1. / x, False, True)
+    res, cumsum = ht.integrate(lambda x: 1.0 / x, False, True)
 
 
 def test_ret_err_and_cumsum():
     ht = HankelTransform(N=50)
-    res, err, cumsum = ht.integrate(lambda x: 1. / x, True, True)
+    res, err, cumsum = ht.integrate(lambda x: 1.0 / x, True, True)
 
 
 def test_equivalence_of_integrate_and_transform():
     ht = HankelTransform(N=50)
     int = ht.integrate(lambda x: 1, False)
-    tr = ht.transform(lambda x: 1. / x, ret_err=False)
+    tr = ht.transform(lambda x: 1.0 / x, ret_err=False)
     assert int == tr

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module provides some tests for the Symmetric Fourier Transforms.
 
 Note that most of the tests in here are mirrored in test_known_integrals, in which k is set to 1.
@@ -6,7 +6,7 @@ Note that most of the tests in here are mirrored in test_known_integrals, in whi
 There is a corresponding notebook in devel/ that runs each of these functions through a grid of N and h,
 showing the pattern of accuracy. This could be useful for finding the correct numbers to choose for these
 for other unknown functions.
-'''
+"""
 
 import numpy as np
 from scipy.special import gamma, gammainc, gammaincc
@@ -17,8 +17,9 @@ gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
 from hankel import SymmetricFourierTransform
 import pytest
 
+
 @pytest.mark.parametrize(
-    's, ndim, k, N, h',
+    "s, ndim, k, N, h",
     [
         [-0.5, 1, 0.01, 50, 0.05],
         [-0.5, 1, 1, 50, 0.05],
@@ -44,19 +45,25 @@ import pytest
         [-1, 3, 0.01, 150, 10 ** -1.5],
         [-1, 3, 1, 150, 10 ** -1.5],
         [-1, 3, 10.0, 150, 10 ** -1.5],
-    ]
+    ],
 )
 def test_powerlaw(s, ndim, k, N, h):
     ht = SymmetricFourierTransform(ndim=ndim, N=N, h=h)
     ans = ht.transform(lambda x: x ** s, k, False, False)
 
-    nu = ndim / 2. - 1
+    nu = ndim / 2.0 - 1
     s += nu
     if nu - s <= 0 and (nu - s) % 2 == 0:
         raise Exception("Can't have a negative integer for gamma")
 
-    anl = (2 * np.pi) ** (ndim / 2.) * 2 ** (s + 1) * gamma(0.5 * (2 + nu + s)) / k ** (s + 2) / gamma(
-        0.5 * (nu - s)) / k ** nu
+    anl = (
+        (2 * np.pi) ** (ndim / 2.0)
+        * 2 ** (s + 1)
+        * gamma(0.5 * (2 + nu + s))
+        / k ** (s + 2)
+        / gamma(0.5 * (nu - s))
+        / k ** nu
+    )
 
     print("Numerical Result: ", ans, " (required %s)" % anl)
     assert np.isclose(ans, anl, rtol=1e-3)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -11,11 +11,11 @@ for other unknown functions.
 import numpy as np
 from scipy.special import gamma, gammainc, gammaincc
 
-gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
-gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
-
 from hankel import SymmetricFourierTransform
 import pytest
+
+gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
+gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_get_h.py
+++ b/tests/test_get_h.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module provides some tests of the integrator to known integrals.
 
 Note, these are not the transformations, just the plain integrals,  :math:`\int_0^\infty f(x) J_\nu(x) dx`
@@ -10,11 +10,11 @@ to ensure that this function works.
 import numpy as np
 from scipy.special import k0, gamma, gammainc, gammaincc
 
-gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
-gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
-
 from hankel import get_h, HankelTransform, SymmetricFourierTransform
 import pytest
+
+gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
+gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_get_h.py
+++ b/tests/test_get_h.py
@@ -1,11 +1,11 @@
-'''
+"""
 This module provides some tests of the integrator to known integrals.
 
 Note, these are not the transformations, just the plain integrals,  :math:`\int_0^\infty f(x) J_\nu(x) dx`
 
 In this module, we use the get_h function, rather than choosing N and h,
 to ensure that this function works.
-'''
+"""
 
 import numpy as np
 from scipy.special import k0, gamma, gammainc, gammaincc
@@ -18,29 +18,25 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'f, anl',
+    "f, anl",
     [
         (lambda x: 1, 1),  # Ogata 05
         (lambda x: x / (x ** 2 + 1), k0(1)),  # Ogata 05
         (lambda x: x ** 2, -1),  # wikipedia
         (lambda x: x ** 4, 9),  # wikipedia
-        (lambda x: 1. / np.sqrt(x),  # wikipedia
-         2 ** (-0.5) * gamma(-1.5 / 2 + 1) / gamma(1.5 / 2)),
-        (lambda x: x / np.sqrt(x ** 2 + 1 ** 2),  # wikipedia
-         np.exp(-1)),
-        (lambda x: x * np.exp(-0.5 * 2 ** 2 * x ** 2),  # wikipedia
-         1. / 2 ** 2 * np.exp(-0.5 / 2 ** 2))
-    ]
+        (
+            lambda x: 1.0 / np.sqrt(x),  # wikipedia
+            2 ** (-0.5) * gamma(-1.5 / 2 + 1) / gamma(1.5 / 2),
+        ),
+        (lambda x: x / np.sqrt(x ** 2 + 1 ** 2), np.exp(-1)),  # wikipedia
+        (
+            lambda x: x * np.exp(-0.5 * 2 ** 2 * x ** 2),  # wikipedia
+            1.0 / 2 ** 2 * np.exp(-0.5 / 2 ** 2),
+        ),
+    ],
 )
 def test_nu0(f, anl):
-    ans = get_h(
-        f=f,
-        nu=0,
-        hstart=0.5,
-        atol=0,
-        rtol=1e-3,
-        maxiter=20,
-    )[1]
+    ans = get_h(f=f, nu=0, hstart=0.5, atol=0, rtol=1e-3, maxiter=20)[1]
     print("Numerical Result: {ans} (required {anl})".format(ans=ans, anl=anl))
     # we ensure that the answer is within 5e-3 of the true answer,
     # because the algorithm does not ensure that the result is within that
@@ -49,24 +45,19 @@ def test_nu0(f, anl):
 
 
 @pytest.mark.parametrize(
-    's, nu, N, h',
+    "s, nu, N, h",
     [
         [0, 1, 50, 0.05],
         [0, 2, 50, 0.05],
         [0.5, 1, 50, 0.05],
         [-2, 2, 600, 10 ** -2.6],  # This is pretty finnicky
-        [-0.783, 1, 50, 0.05]
-    ]
+        [-0.783, 1, 50, 0.05],
+    ],
 )
 def test_nu_varying_powerlaw(s, nu, N, h):
     # For this one we test the transform instead
     ans = get_h(
-        f=lambda x: x ** s,
-        nu=nu,
-        K=1,
-        hstart=0.5,
-        atol=1e-3,
-        rtol=1e-3,
+        f=lambda x: x ** s, nu=nu, K=1, hstart=0.5, atol=1e-3, rtol=1e-3
     )[1]
 
     anl = 2 ** (s + 1) * gamma(0.5 * (2 + nu + s)) / gamma(0.5 * (nu - s))
@@ -75,12 +66,8 @@ def test_nu_varying_powerlaw(s, nu, N, h):
 
 
 @pytest.mark.parametrize(
-    's, nu, N, h',
-    [
-        [0.5, 1, 50, 0.05],
-        [0.783, 1, 50, 0.05],
-        [1.0, 0.5, 500, 0.01],
-    ]
+    "s, nu, N, h",
+    [[0.5, 1, 50, 0.05], [0.783, 1, 50, 0.05], [1.0, 0.5, 500, 0.01]],
 )
 def test_nu_varying_gamma_mod(s, nu, N, h):
     ans = get_h(

--- a/tests/test_known_integrals.py
+++ b/tests/test_known_integrals.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module provides some tests of the integrator to known integrals.
 
 Note, these are not the transformations, just the plain integrals,  :math:`\int_0^\infty f(x) J_\nu(x) dx`
@@ -6,7 +6,7 @@ Note, these are not the transformations, just the plain integrals,  :math:`\int_
 There is a corresponding notebook in devel/ that runs each of these functions through a grid of N and h,
 showing the pattern of accuracy. This could be useful for finding the correct numbers to choose for these
 for other unknown functions.
-'''
+"""
 
 import numpy as np
 from scipy.special import k0, gamma, gammainc, gammaincc
@@ -73,7 +73,7 @@ def test_nu0_1_on_sqrt_x():
     """
     # NOTE: this is REALLY finnicky!! (check devel/)
     ht = HankelTransform(nu=0, N=160, h=10 ** -3.5)
-    ans = ht.integrate(lambda x: 1. / np.sqrt(x), False, False)
+    ans = ht.integrate(lambda x: 1.0 / np.sqrt(x), False, False)
     m = -1.5
     anl = 2 ** (m + 1) * gamma(m / 2 + 1) / gamma(-m / 2)
 
@@ -102,21 +102,23 @@ def test_nu0_f_gauss():
     z = 2
     ht = HankelTransform(nu=0, N=50, h=0.01)
 
-    ans = ht.integrate(lambda x: x * np.exp(-0.5 * z ** 2 * x ** 2), False, False)
-    anl = 1. / z ** 2 * np.exp(-0.5 / z ** 2)
+    ans = ht.integrate(
+        lambda x: x * np.exp(-0.5 * z ** 2 * x ** 2), False, False
+    )
+    anl = 1.0 / z ** 2 * np.exp(-0.5 / z ** 2)
     print("Numerical Result: ", ans, " (required %s)" % anl)
     assert np.isclose(ans, anl, rtol=1e-3)
 
 
 @pytest.mark.parametrize(
-    's, nu, N, h',
+    "s, nu, N, h",
     [
         [0, 1, 50, 0.05],
         [0, 2, 50, 0.05],
         [0.5, 1, 50, 0.05],
         [-2, 2, 600, 10 ** -2.6],  # This is pretty finnicky
-        [-0.783, 1, 50, 0.05]
-    ]
+        [-0.783, 1, 50, 0.05],
+    ],
 )
 def test_nu_varying_powerlaw(s, nu, N, h):
     ht = HankelTransform(nu=nu, N=N, h=h)
@@ -129,17 +131,15 @@ def test_nu_varying_powerlaw(s, nu, N, h):
 
 
 @pytest.mark.parametrize(
-    's, nu, N, h',
-    [
-        [0.5, 1, 50, 0.05],
-        [0.783, 1, 50, 0.05],
-        [1.0, 0.5, 500, 0.01],
-    ]
+    "s, nu, N, h",
+    [[0.5, 1, 50, 0.05], [0.783, 1, 50, 0.05], [1.0, 0.5, 500, 0.01]],
 )
 def test_nu_varying_gamma_mod(s, nu, N, h):
     ht = HankelTransform(nu=nu, N=N, h=h)
 
-    ans = ht.integrate(lambda x: x ** (nu - 2 * s + 1) * gammainc_(s, x ** 2), False, False)
+    ans = ht.integrate(
+        lambda x: x ** (nu - 2 * s + 1) * gammainc_(s, x ** 2), False, False
+    )
     anl = 0.5 ** (2 * s - nu - 1) * gammaincc_(1 - s + nu, 0.25)
 
     print("Numerical Result: ", ans, " (required %s)" % anl)

--- a/tests/test_known_integrals.py
+++ b/tests/test_known_integrals.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module provides some tests of the integrator to known integrals.
 
 Note, these are not the transformations, just the plain integrals,  :math:`\int_0^\infty f(x) J_\nu(x) dx`
@@ -10,12 +10,11 @@ for other unknown functions.
 
 import numpy as np
 from scipy.special import k0, gamma, gammainc, gammaincc
+from hankel import HankelTransform
+import pytest
 
 gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
 gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
-
-from hankel import HankelTransform
-import pytest
 
 
 def test_nu0_f_unity():

--- a/tests/test_round_trip.py
+++ b/tests/test_round_trip.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module provides tests that ensure that the forward then backward transform ends up with the original.
 
 For simplicity and because of common use (for me at least), we do this with a broken powerlaw, which turns
@@ -8,7 +8,7 @@ correctly (some here are commented out because they don't fit the convergence cr
 There is a corresponding notebook in devel/ that runs each of these functions through a grid of N and h,
 showing the pattern of accuracy. This could be useful for finding the correct numbers to choose for these
 for other unknown functions.
-'''
+"""
 
 import numpy as np
 import pytest
@@ -16,11 +16,11 @@ from scipy.interpolate import InterpolatedUnivariateSpline as spline
 
 from hankel import SymmetricFourierTransform
 
-r = np.array([0.1, 1, 10.])
+r = np.array([0.1, 1, 10.0])
 
 
 @pytest.mark.parametrize(
-    's, t, x0, ndim, N, h, r',
+    "s, t, x0, ndim, N, h, r",
     [
         [0, 1, 1, 2, 1100, 10 ** -2.5, r],
         [0, 2, 1, 2, 800, 10 ** -2.6, r],
@@ -50,13 +50,17 @@ r = np.array([0.1, 1, 10.])
         # [3, 1, 10, 3, 50, 0.05, r],
         # [3, 2, 10, 3, 50, 0.05, r],
         # [3, 3, 10, 3, 50, 0.05, r],
-    ]
+    ],
 )
 def test_roundtrip_broken_pl(s, t, x0, ndim, N, h, r):
     f = lambda x: x ** s / (x ** t + x0)
     ht = SymmetricFourierTransform(ndim=ndim, N=N, h=h)
 
-    k = np.logspace(np.log10(ht.x.min() / r.max() / 10.0), np.log10(10 * ht.x.max() / r.min()), 1000)
+    k = np.logspace(
+        np.log10(ht.x.min() / r.max() / 10.0),
+        np.log10(10 * ht.x.max() / r.min()),
+        1000,
+    )
     resk = ht.transform(f, k, False)
     spl = spline(k, resk)
     res = ht.transform(spl, r, False, inverse=True)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -105,3 +105,33 @@ def test_alternative(s, nu, k, N, h):
     ft2 = ht2.transform(lambda r: r ** (s + 0.5), k, False, False) / k ** 0.5
     print("Numerical Results: ", ft1, " and ", ft2)
     assert np.isclose(ft1, ft2, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "nu, alt",
+    [
+        [-0.5, False],
+        [0, False],
+        [0.5, False],
+        [1, False],
+        [1.5, False],
+        [-0.5, True],
+        [0, True],
+        [0.5, True],
+        [1, True],
+        [1.5, True],
+    ],
+)
+def test_k_zero(nu, alt):
+    """Testing k=0."""
+    threshold = -0.5 if alt else 0
+    f = lambda r: np.exp(-r ** 2 / 2)
+    ht = HankelTransform(nu=nu, N=50, h=1e-3, alt=alt)
+    ans = ht.transform(f, 0, False, False)
+    print("Numerical Results: ", ans)
+    if nu < threshold:
+        assert np.isinf(ans)
+    elif nu > threshold:
+        assert np.isclose(ans, 0, rtol=1e-3)
+    else:
+        assert np.isclose(ans, 1, rtol=1e-3)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -61,3 +61,42 @@ def test_powerlaw(s, nu, k, N, h):
 
     print("Numerical Result: ", ans, " (required %s)" % anl)
     assert np.isclose(ans, anl, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    's, nu, k, N, h',
+    [
+        [-2, 1, 0.01, 300, 10 ** -3.2],
+        [-2, 1, 1, 300, 10 ** -3.2],
+        [-2, 1, 10.0, 300, 10 ** -3.2],
+        [-2, 2, 0.01, 200, 10 ** -2.],
+        [-2, 2, 1, 200, 10 ** -2.],
+        [-2, 2, 10.0, 200, 10 ** -2.],
+        [-1, 0, 0.01, 50, 0.05],
+        [-1, 0, 1, 50, 0.05],
+        [-1, 0, 10.0, 50, 0.05],
+        [-1, 1, 0.01, 50, 0.05],
+        [-1, 1, 1, 50, 0.05],
+        [-1, 1, 10.0, 50, 0.05],
+        [-1, 2, 0.01, 50, 0.05],
+        [-1, 2, 1, 50, 0.05],
+        [-1, 2, 10.0, 50, 0.05],
+        [1, 0, 0.01, 150, 10 ** -1.5],
+        [1, 0, 1, 150, 10 ** -1.5],
+        [1, 0, 10.0, 150, 10 ** -1.5],
+        [1, 2, 0.01, 50, 0.05],
+        [1, 2, 1, 50, 0.05],
+        [1, 2, 10.0, 50, 0.05],
+        [2, 1, 0.01, 100, 10 ** -1.5],
+        [2, 1, 1, 100, 10 ** -1.5],
+        [2, 1, 10.0, 100, 10 ** -1.5],
+    ]
+)
+def test_alternative(s, nu, k, N, h):
+    """Test alternative hankel definition."""
+    ht1 = HankelTransform(nu=nu, N=N, h=h)
+    ht2 = HankelTransform(nu=nu, N=N, h=h, alt=True)
+    ft1 = ht1.transform(lambda r: r ** s, k, False, False)
+    ft2 = ht2.transform(lambda r: r ** (s + 0.5), k, False, False) / k ** 0.5
+    print("Numerical Results: ", ft1, " and ", ft2)
+    assert np.isclose(ft1, ft2, rtol=1e-3)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -130,7 +130,7 @@ def test_k_zero(nu, alt):
     ans = ht.transform(f, 0, False, False)
     print("Numerical Results: ", ans)
     if nu < threshold:
-        assert np.isinf(ans)
+        assert np.isnan(ans)
     elif nu > threshold:
         assert np.isclose(ans, 0, rtol=1e-3)
     else:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -11,11 +11,11 @@ for other unknown functions.
 import numpy as np
 from scipy.special import gamma, gammainc, gammaincc
 
-gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
-gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
-
 from hankel import HankelTransform
 import pytest
+
+gammainc_ = lambda a, x: gamma(a) * gammainc(a, x)
+gammaincc_ = lambda a, x: gamma(a) * gammaincc(a, x)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module provides some tests of the transform, based on analytic transforms provided by Wikipedia.
 
 Note that most of the tests in here are mirrored in test_known_integrals, in which k is set to 1.
@@ -6,7 +6,7 @@ Note that most of the tests in here are mirrored in test_known_integrals, in whi
 There is a corresponding notebook in devel/ that runs each of these functions through a grid of N and h,
 showing the pattern of accuracy. This could be useful for finding the correct numbers to choose for these
 for other unknown functions.
-'''
+"""
 
 import numpy as np
 from scipy.special import gamma, gammainc, gammaincc
@@ -19,14 +19,14 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    's, nu, k, N, h',
+    "s, nu, k, N, h",
     [
         [-2, 1, 0.01, 300, 10 ** -3.2],
         [-2, 1, 1, 300, 10 ** -3.2],
         [-2, 1, 10.0, 300, 10 ** -3.2],
-        [-2, 2, 0.01, 200, 10 ** -2.],
-        [-2, 2, 1, 200, 10 ** -2.],
-        [-2, 2, 10.0, 200, 10 ** -2.],
+        [-2, 2, 0.01, 200, 10 ** -2.0],
+        [-2, 2, 1, 200, 10 ** -2.0],
+        [-2, 2, 10.0, 200, 10 ** -2.0],
         [-1, 0, 0.01, 50, 0.05],
         [-1, 0, 1, 50, 0.05],
         [-1, 0, 10.0, 50, 0.05],
@@ -45,7 +45,7 @@ import pytest
         [2, 1, 0.01, 100, 10 ** -1.5],
         [2, 1, 1, 100, 10 ** -1.5],
         [2, 1, 10.0, 100, 10 ** -1.5],
-    ]
+    ],
 )
 def test_powerlaw(s, nu, k, N, h):
     """
@@ -57,21 +57,26 @@ def test_powerlaw(s, nu, k, N, h):
     if nu - s <= 0 and (nu - s) % 2 == 0:
         raise Exception("Can't have a negative integer for gamma")
 
-    anl = 2 ** (s + 1) * gamma(0.5 * (2 + nu + s)) / k ** (s + 2) / gamma(0.5 * (nu - s))
+    anl = (
+        2 ** (s + 1)
+        * gamma(0.5 * (2 + nu + s))
+        / k ** (s + 2)
+        / gamma(0.5 * (nu - s))
+    )
 
     print("Numerical Result: ", ans, " (required %s)" % anl)
     assert np.isclose(ans, anl, rtol=1e-3)
 
 
 @pytest.mark.parametrize(
-    's, nu, k, N, h',
+    "s, nu, k, N, h",
     [
         [-2, 1, 0.01, 300, 10 ** -3.2],
         [-2, 1, 1, 300, 10 ** -3.2],
         [-2, 1, 10.0, 300, 10 ** -3.2],
-        [-2, 2, 0.01, 200, 10 ** -2.],
-        [-2, 2, 1, 200, 10 ** -2.],
-        [-2, 2, 10.0, 200, 10 ** -2.],
+        [-2, 2, 0.01, 200, 10 ** -2.0],
+        [-2, 2, 1, 200, 10 ** -2.0],
+        [-2, 2, 10.0, 200, 10 ** -2.0],
         [-1, 0, 0.01, 50, 0.05],
         [-1, 0, 1, 50, 0.05],
         [-1, 0, 10.0, 50, 0.05],
@@ -90,7 +95,7 @@ def test_powerlaw(s, nu, k, N, h):
         [2, 1, 0.01, 100, 10 ** -1.5],
         [2, 1, 1, 100, 10 ** -1.5],
         [2, 1, 10.0, 100, 10 ** -1.5],
-    ]
+    ],
 )
 def test_alternative(s, nu, k, N, h):
     """Test alternative hankel definition."""


### PR DESCRIPTION
This PR addresses multiple points:
- adding the alternative hankel transform definition (https://en.wikipedia.org/wiki/Hankel_transform#Alternative_definition)
- handling the input of ``k=0`` by explicit integration
- better handling of the FourierTransform with using the alternative hankel definition
- restructuring:
  - ~~using _f again to call function correctly~~
  - replacing ``_x_power`` with ``_r_power`` ~~and using it in _f~~
  - bloated methods in separate ``tools.py`` for cleanup
- adding test for the alternative hankel definition