### PR TITLE
update deployment in travis and add version file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,9 @@ jobs:
 
     # Deploy source distribution
     - stage: deploy
+      if: tag IS present
       python: 3.8
       name: Deploy source distribution
       install: python -m pip install -U setuptools wheel twine
       script: python setup.py sdist --formats=gztar bdist_wheel
       after_success: python -m twine upload --skip-existing dist/*
-      on:
-        tags: true
-        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,8 @@ stages:
   - lint
   - test
   - coverage
-  - name: test_deploy
-    if: (NOT type IN (pull_request)) AND (repo = steven-murray/hankel)
   - name: deploy
-    if: (NOT type IN (pull_request)) AND (repo = steven-murray/hankel) AND (branch = master) AND (tag IS present)
+    if: (NOT type IN (pull_request)) AND (repo = steven-murray/hankel)
 
 jobs:
   include:
@@ -69,7 +67,7 @@ jobs:
       name: Coverage on Linux
 
     # Test Deploy source distribution
-    - stage: test_deploy
+    - stage: deploy
       python: 3.8
       name: Test Deploy
       install: python -m pip install -U setuptools wheel twine
@@ -84,3 +82,6 @@ jobs:
       install: python -m pip install -U setuptools wheel twine
       script: python setup.py sdist --formats=gztar bdist_wheel
       after_success: python -m twine upload --skip-existing dist/*
+      on:
+        tags: true
+        branch: master

--- a/hankel/__init__.py
+++ b/hankel/__init__.py
@@ -22,14 +22,12 @@ Functions
    get_h
 
 """
-from pkg_resources import DistributionNotFound, get_distribution
-
 from hankel.hankel import HankelTransform, SymmetricFourierTransform
 from hankel.tools import get_h
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:  # pragma: nocover
+    from hankel._version import __version__
+except ModuleNotFoundError:  # pragma: nocover
     # package is not installed
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@ def read(*names, **kwargs):
         return fp.read()
 
 
+    def local_scheme(version):
+    """Skip the local version (eg. +xyz of 1.0.1.dev1+xyz) to be able to upload to Test PyPI."""
+    return ""
+
+
 CLASSIFIERS = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -51,7 +56,7 @@ setup(
     author_email="steven.murray@curtin.edu.au",
     license="MIT",
     extras_require={"dev": test_req + doc_req, "tests": test_req, "docs": doc_req},
-    use_scm_version=True,
+    use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
     url="https://github.com/steven-murray/hankel",
 )

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ def read(*names, **kwargs):
         return fp.read()
 
 
-    def local_scheme(version):
-    """Skip the local version (eg. +xyz of 1.0.1.dev1+xyz) to be able to upload to Test PyPI."""
+def local_scheme(version):
+    """Truncate the local version (eg. +xyz of 1.0.1.dev1+xyz) for Test PyPI."""
     return ""
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,13 @@ setup(
     author_email="steven.murray@curtin.edu.au",
     license="MIT",
     extras_require={"dev": test_req + doc_req, "tests": test_req, "docs": doc_req},
-    use_scm_version={"local_scheme": local_scheme},
+    use_scm_version={
+        "root": ".",
+        "relative_to": __file__,
+        "write_to": "hankel/_version.py",
+        "write_to_template": "__version__ = '{version}'",
+        "local_scheme": local_scheme,
+    },
     setup_requires=["setuptools_scm"],
     url="https://github.com/steven-murray/hankel",
 )

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "write_to": "hankel/_version.py",
         "write_to_template": "__version__ = '{version}'",
         "local_scheme": local_scheme,
+        "fallback_version": "0.0.0.dev0",
     },
     setup_requires=["setuptools_scm"],
     url="https://github.com/steven-murray/hankel",


### PR DESCRIPTION
Added check for tags to the deploy job itself.
Now there is only one deploy stage.

Local versioning is now truncated to `x.y.z.devN` to be able to upload to test.pypi.
In the future `setuptools_scm` will be following the SemVer rules, so we could revert this at some point.

A version file is now written to get the version at runtime without the help of external packages.